### PR TITLE
54892 Timesheet > Close Time invaild date

### DIFF
--- a/angular/src/app/modules/timesheet/create-edit-timesheet/create-edit-timesheet.component.ts
+++ b/angular/src/app/modules/timesheet/create-edit-timesheet/create-edit-timesheet.component.ts
@@ -57,7 +57,7 @@ export class CreateEditTimesheetComponent extends AppComponentBase implements On
   }
   SaveAndClose() {
     this.isDisable = true
-    this.timesheet.closeTime = (this.submitDate && this.submitDate !== "Invalid date") ? this.submitDate : '';
+    this.submitDate = (this.submitDate && this.submitDate !== "Invalid date") ? this.submitDate : '';
     if (this.data.command == "create") {
       this.timesheet.isActive = true;
       this.timesheetService.create(this.timesheet).pipe(catchError(this.timesheetService.handleError)).subscribe((res) => {

--- a/angular/src/app/modules/timesheet/create-edit-timesheet/create-edit-timesheet.component.ts
+++ b/angular/src/app/modules/timesheet/create-edit-timesheet/create-edit-timesheet.component.ts
@@ -57,7 +57,7 @@ export class CreateEditTimesheetComponent extends AppComponentBase implements On
   }
   SaveAndClose() {
     this.isDisable = true
-    this.timesheet.closeTime = this.submitDate;
+    this.timesheet.closeTime = (this.submitDate && this.submitDate !== "Invalid date") ? this.submitDate : '';
     if (this.data.command == "create") {
       this.timesheet.isActive = true;
       this.timesheetService.create(this.timesheet).pipe(catchError(this.timesheetService.handleError)).subscribe((res) => {

--- a/angular/src/app/modules/timesheet/create-edit-timesheet/create-edit-timesheet.component.ts
+++ b/angular/src/app/modules/timesheet/create-edit-timesheet/create-edit-timesheet.component.ts
@@ -57,7 +57,7 @@ export class CreateEditTimesheetComponent extends AppComponentBase implements On
   }
   SaveAndClose() {
     this.isDisable = true
-    this.submitDate = (this.submitDate && this.submitDate !== "Invalid date") ? this.submitDate : '';
+    this.timesheet.closeTime = (this.submitDate && this.submitDate !== "Invalid date") ? this.submitDate : '';
     if (this.data.command == "create") {
       this.timesheet.isActive = true;
       this.timesheetService.create(this.timesheet).pipe(catchError(this.timesheetService.handleError)).subscribe((res) => {


### PR DESCRIPTION
When you modify the timesheet but do not interact with Close Time (Close Time is not necessary), it cannot save and returns "Your required is not valid." The API returns CloseTime as "Invaild date," rather than a null value.
![Screenshot 2024-02-21 160016](https://github.com/ncc-erp/ncc-erp-project/assets/153714985/82069b23-77fe-4197-8e95-72ba3bc04483)
