### PR TITLE
feat: background color for contribute bill account and tooltip

### DIFF
--- a/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.html
+++ b/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.html
@@ -357,7 +357,7 @@
                           <i class="fa fa-plus fa-s m-0"></i>
                         </button>
                       </div>
-                      <div class="d-flex row">
+                      <div class="d-flex row" style="width: 380px;">
                         <div class="d-flex col-12 px-0" style="flex-direction: column;">
                           <div *ngFor="let resource of  project.linkedResources; let i = index" class="mb-2 d-flex px-0">
                             <div class="col-8 d-flex px-0">
@@ -371,7 +371,10 @@
                             <div class="col-4 d-flex px-0">
                               <div class="col-6 align-items-end d-flex" [ngClass]="{'col-12': editingRows[project.billId] && editingRows[project.billId][i]?.contribute}">
                                 <span *ngIf="!editingRows[project.billId] || !editingRows[project.billId][i]?.contribute"
-                                  class="badge bg-info">{{resource.contribute + '%'}}
+                                  class="badge text-white" 
+                                  [style.backgroundColor]="Utils.getColorContribute(resource.contribute)"
+                                  matTooltip="Contribute account">
+                                  {{resource.contribute + '%'}}
                                 </span>
                                 <input *ngIf="editingRows[project.billId] && editingRows[project.billId][i]?.contribute" 
                                   type="number" 

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
@@ -331,7 +331,7 @@
 
                                     </div>
                                 </td>
-                                <td>
+                                <td style="width: 400px;">
                                     <div class="text-right" *ngIf="!bill.createLinkResourceMode">
                                         <button *ngIf="permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount)"
                                            (click)="addLinkResource(bill)"
@@ -401,7 +401,12 @@
                                                 </div>
                                                 <div class="col-4 d-flex px-0">
                                                     <div class="col-6 align-items-end d-flex" [ngClass]="{'col-12': editingRows[bill.id] && editingRows[bill.id][i]?.contribute}">
-                                                        <span *ngIf="!editingRows[bill.id] || !editingRows[bill.id][i]?.contribute"  class="badge bg-info">{{resource.contribute + '%'}}</span>
+                                                        <span *ngIf="!editingRows[bill.id] || !editingRows[bill.id][i]?.contribute"  
+                                                            class="badge text-white" 
+                                                            [style.backgroundColor]="Utils.getColorContribute(resource.contribute)"
+                                                            matTooltip="Contribute account">
+                                                            {{resource.contribute + '%'}}
+                                                        </span>
                                                         <input  
                                                             *ngIf="editingRows[bill.id] && editingRows[bill.id][i]?.contribute" 
                                                             type="number"

--- a/angular/src/shared/Utils.ts
+++ b/angular/src/shared/Utils.ts
@@ -184,4 +184,28 @@ export class Utils {
       }
     }
   }
+  
+  public static getColorContribute(contribute: number): string {
+    // https://github.com/orgs/community/discussions/7078
+    // Category: Winter color
+    const COLORS = {
+      LEVEL_1: "#b6e3ff", // blue level 1
+      LEVEL_2: "#54aeff", // blue level 2
+      LEVEL_3: "#0969da", // blue level 3
+      LEVEL_4: "#0a3069"  // blue level 4
+    };
+
+    if (contribute < 0 || contribute > 100) {
+      return ""; // out-of-bounds case
+    } else if (contribute < 25) {
+      return COLORS.LEVEL_1;
+    } else if (contribute < 50) {
+      return COLORS.LEVEL_2;
+    } else if (contribute < 75) {
+      return COLORS.LEVEL_3;
+    } else {
+      return COLORS.LEVEL_4;
+    }
+  }
+
 }


### PR DESCRIPTION
III. Contribute acc
	1. bộ màu cho contribute acc: theo github, 4 mức
		>= 70%: blue
		>= 50: 
		>= 25:
		>= 0: 
               ![image](https://github.com/user-attachments/assets/a739483c-8195-4832-9df7-ef6ccd11c97e)
	2. hover con số % -> hiện tooltip: contribute account
	