### PR TITLE
Enhance Bill Accounts with Skills Column and UX Improvements

### DIFF
--- a/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.css
+++ b/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.css
@@ -47,6 +47,11 @@
   border: none;
 }
 
+.btn-sm:hover{
+  background: #c3c3c3;
+  border-radius: 5px;
+}
+
 @media screen and (max-width: 600px) {
   .content {
     padding-left: 0 !important;

--- a/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.html
+++ b/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.html
@@ -201,7 +201,7 @@
         </div>
       </div>
 
-      <div class="table-responsive py-4 all-resource-table">
+      <div class="py-4 all-resource-table">
         <div class="fixTableHead">
           <table style="border-collapse: collapse" class="table text-nowrap">
             <thead>
@@ -209,6 +209,7 @@
                 <th
                   *ngFor="let thead of theadTable; let i = index"
                   [style.width]="thead.width"
+                  [style.maxWidth]="thead?.maxWidth"
                   [style.padding]="thead?.padding"
                   [style.whiteSpace]="thead?.whiteSpace"
                   class="text-center"
@@ -219,9 +220,7 @@
                   >
                     <div class="rsp-th-name">
                       <ng-container *ngIf="thead.name === 'Head Count'; else defaultThead" >
-                       <div style="margin-top: 26px;">
                         {{ thead.name }} ({{ totalHeadCount }})
-                      </div>
                       </ng-container>
                       <ng-template #defaultThead>
                         {{ thead.name }}
@@ -271,95 +270,118 @@
                 
                 <tr *ngFor="let project of item.projects; let j = index">
                     <td>
-                        <span>{{ project.clientName }}</span>
+                        {{ project.clientName }}
                     </td>
-
-                    <td style="width: 180px; padding: 3px">
+                    <td class="p-1">
+                      <div class="d-flex flex-column">
                         <div class="d-flex flex-column">
-                            <div>
-                                <div class="d-flex flex-column">
-                                    <div class="project_link--wapper">
-                                        <a href="{{ viewProjectDetail(project) }}"
-                                           class="project-link">
-                                            <strong>{{ project.projectName }}</strong>
-                                        </a>
-                                        <span [outerHTML]="
-                                project.projectStatus | projectStatusPipe
-                              "></span>
-                                    </div>
-                                    <span>{{ project.accountName }}</span>
-                                    <span *ngIf="isShowBillRate">{{project.rateDisplay}}</span>
-                                </div>
-                            </div>
+                          <div class="project_link--wapper">
+                            <a href="{{ viewProjectDetail(project) }}" class="project-link">
+                              <strong>{{ project.projectName }}</strong>
+                            </a>
+                            <span [outerHTML]="project.projectStatus | projectStatusPipe"></span>
+                          </div>
+                          <span>{{ project.accountName }}</span>
+                          <span *ngIf="isShowBillRate">{{project.rateDisplay}}</span>
                         </div>
+                      </div>
                     </td>
-
-                    <td>
-                        <span class="d-flex flex-column align-items-center">
-                            <mat-checkbox color="primary"
-                                          [disabled]="true"
-                                          [(ngModel)]="project.isActive"></mat-checkbox>
+                    <td *ngIf="j === 0"
+                      [attr.rowspan]="item.projects.length"
+                      style="max-width: 300px; position: relative; vertical-align: top;">
+                      <div *ngFor="let skill of (isViewAllUserSkill[item.userInfor.userId] ? item.userInfor.userSkills : item.userInfor.userSkills.slice(0, numberSkill))">
+                        <span>
+                          - {{skill.skillName}}
+                          <strong *ngIf="skill.skillRank && permission.isGranted(Resource_TabAllResource_ViewUserStarSkill)">
+                            - {{skill.skillRank}}
+                            <i class="fa fa-star"
+                              [ngStyle]="{color: skill.skillRank === 5 ? 'crimson' :
+                                skill.skillRank === 4 ? 'orange' :
+                                skill.skillRank === 3 ? 'yellow' :
+                                skill.skillRank === 1 || skill.skillRank === 2 ? 'grey' : 'inherit'
+                              }"
+                              style="font-size: 13px;">
+                            </i>
+                          </strong>
                         </span>
+                        <ng-container
+                          *ngIf="!isViewAllUserSkill[item.userInfor.userId] && item.userInfor.userSkills.length > numberSkill && skill === (item.userInfor.userSkills.slice(0, numberSkill)[numberSkill - 1])">
+                          <button class="btn btn-sm"
+                            (click)="expandCollapseUserSkill(item.userInfor.userId);">
+                            <i class="fas fa-ellipsis-h"></i>
+                          </button>
+                        </ng-container>
+                        <ng-container
+                          *ngIf="isViewAllUserSkill[item.userInfor.userId] && skill === (item.userInfor.userSkills[item.userInfor.userSkills.length - 1])">
+                          <button class="btn btn-sm"
+                            (click)="expandCollapseUserSkill(item.userInfor.userId);">
+                            <i class="fas fa-chevron-up"></i>
+                          </button>
+                        </ng-container>
+                      </div>
+                      <div *ngIf="item.userInfor.skillNote">
+                        <pre class="mb-0 p-0 max-line-content-2" PrjResizeContent [collapseLine]="2" style="
+                                                    white-space: pre-line;
+                                                    font-family: sans-serif;
+                                                    align-self: flex-start;
+                                                    line-height: initial;
+                                                  ">
+                                                      <strong>Note: </strong> {{item.userInfor.skillNote}}
+                                                </pre>
+                      </div>
+                      <button class="btn btn-sm"
+                        style="position: absolute; top: 0; right: 0;"
+                        *ngIf="permission.isGranted(Resource_TabAllResource_UpdateSkill)"
+                        (click)="updateUserSkill(item.userInfor, item.userInfor.skillNote)">
+                        <i class="fas fa-edit"></i>
+                      </button>
                     </td>
-
                     <td>
                       <span class="d-flex flex-column align-items-center">
-                          <mat-checkbox color="primary"
-                                        [disabled]="true"
-                                        [(ngModel)]="project.isExpose"></mat-checkbox>
+                        <mat-checkbox color="primary"
+                          [disabled]="true"
+                          [(ngModel)]="project.isActive">
+                        </mat-checkbox>
                       </span>
-                  </td>
-
-                <td >
-                    <span class="d-flex flex-column align-items-center"[(ngModel)]="project.headCount">
-                       {{project.headCount}}
-                    </span>
-                </td>
-
+                    </td>
                     <td>
-                        <span class="d-flex flex-column align-items-center"
-                              [ngClass]="{
-                        redColor: checkTimeInFilterDate(project.startTime)
-                      }">{{ project.startTime | date : "dd-MM-yyyy" }}</span>
-                        <span class="d-flex flex-column align-items-center"
-                              [ngClass]="{
-                        redColor: checkTimeInFilterDate(project.endTime)
-                      }">{{ project.endTime | date : "dd-MM-yyyy" }}</span>
+                      <span class="d-flex flex-column align-items-center">
+                        <mat-checkbox color="primary"
+                          [disabled]="true"
+                          [(ngModel)]="project.isExpose">
+                        </mat-checkbox>
+                      </span>
                     </td>
-
-                    <td style="display: none;">
-                        <div class="d-flex align-items-start justify-content-end">
-                            <div class="d-flex" style="flex-direction: column;">
-                                  <div *ngFor="let resource of  project.linkedResources" class="mb-2 position-relative">
-                                      <app-user-info [userData]="resource"
-                                                    [isHideEmail]="true"
-                                                    [isWeeklyReport]="false"
-                                                    [isSmallerDiv]="true"
-                                                    [viewMode] ="1">
-                                      </app-user-info>
-                                      <i *ngIf="true" (click)="removeLinkResource(resource.id, project.billId)"
-                                        class="fa fa-times position-absolute" style="top:32px; right: -28px;"></i>
-                                  </div>
-                            </div>
-                            <i *ngIf="true"
-                               (click)="handleOpenDialogShadowAccount(project.projectId, item.userInfor.userId, project.linkedResources, project.billId)"
-                               class="btn bg-blue ml-2 btn-sm mb-2"
-                               style="cursor: pointer; font-size: 10px;">
-                                <i class="fa fa-plus fa-s m-0"></i>
-                            </i>
-                        </div>
+                    <td>
+                      <span class="d-flex flex-column align-items-center"
+                        [(ngModel)]="project.headCount">
+                        {{project.headCount}}
+                      </span>
                     </td>
+                    <td>
+                      <span class="d-flex flex-column align-items-center"
+                        [ngClass]="{redColor: checkTimeInFilterDate(project.startTime)}">
+                        {{ project.startTime | date : "dd-MM-yyyy" }}
+                      </span>
+                      <span class="d-flex flex-column align-items-center"
+                        [ngClass]="{redColor: checkTimeInFilterDate(project.endTime)}">
+                        {{ project.endTime | date : "dd-MM-yyyy" }}
+                      </span>
+                    </td>              
                     <td style="width: 380px;">
                       <div class="d-flex align-items-start justify-content-end">
-                        <button
+                        <button class="btn bg-blue btn-sm"
                           (click)="handleOpenDialogShadowAccount(project.projectId, item.userInfor.userId, project.linkedResources, project.billId)"
-                          class="btn bg-blue btn-sm" style="cursor: pointer; font-size: 10px;">
+                          style="cursor: pointer; font-size: 10px;">
                           <i class="fa fa-plus fa-s m-0"></i>
                         </button>
                       </div>
-                      <div class="d-flex row" style="width: 380px;">
-                        <div class="d-flex col-12 px-0" style="flex-direction: column;">
-                          <div *ngFor="let resource of  project.linkedResources; let i = index" class="mb-2 d-flex px-0">
+                      <div class="d-flex row"
+                        style="width: 380px;">
+                        <div class="d-flex col-12 px-0"
+                          style="flex-direction: column;">
+                          <div *ngFor="let resource of  project.linkedResources; let i = index"
+                            class="mb-2 d-flex px-0">
                             <div class="col-8 d-flex px-0">
                               <app-user-info [userData]="resource" 
                                 [isHideEmail]="true" 
@@ -369,7 +391,8 @@
                               </app-user-info>
                             </div>
                             <div class="col-4 d-flex px-0">
-                              <div class="col-6 align-items-end d-flex" [ngClass]="{'col-12': editingRows[project.billId] && editingRows[project.billId][i]?.contribute}">
+                              <div class="col-6 align-items-end d-flex"
+                                [ngClass]="{'col-12': editingRows[project.billId] && editingRows[project.billId][i]?.contribute}">
                                 <span *ngIf="!editingRows[project.billId] || !editingRows[project.billId][i]?.contribute"
                                   class="badge text-white" 
                                   [style.backgroundColor]="Utils.getColorContribute(resource.contribute)"
@@ -406,20 +429,14 @@
                         </div>
                       </div>
                     </td>
-
-                    <td class="note-edit" style="padding: 3px">
-                        <div class="d-flex">
-                            <span>{{ project.note }}</span>
-                            <i class="fas fa-edit note_edit--icon"
-                               (click)="
-                          UpdateBillNote(
-                            item.userInfor,
-                            project.projectId,
-                            project.note,
-                            project.projectName
-                          )
-                        "></i>
-                        </div>
+                    <td class="note-edit"
+                      style="padding: 3px; min-width: 200px; width: 100%">
+                      <div class="d-flex">
+                          <span>{{ project.note }}</span>
+                          <i class="fas fa-edit note_edit--icon"
+                            (click)="UpdateBillNote(item.userInfor,project.projectId,project.note,project.projectName)">
+                          </i>
+                      </div>
                     </td>
                 </tr>
               </ng-container>

--- a/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.ts
+++ b/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.ts
@@ -12,6 +12,9 @@ import { THeadTable } from "../../request-resource-tab/request-resource-tab.comp
 import { MatDialog } from "@angular/material/dialog";
 import { HandleLinkedResourcesDialogComponent } from './handle-linked-resources-dialog/handle-linked-resources-dialog.component';
 import { ProjectUserBillService } from '@app/service/api/project-user-bill.service';
+import { PERMISSIONS_CONSTANT } from '@app/constant/permission.constant';
+import { projectUserBillDto } from '@app/service/model/project.dto';
+import { UpdateUserSkillDialogComponent } from '@app/users/update-user-skill-dialog/update-user-skill-dialog.component';
 
 @Component({
   selector: "app-bill-account-plan",
@@ -41,15 +44,16 @@ export class BillAccountPlanComponent
   public listAllResource = []
 
   public theadTable: THeadTable[] = [
-    { name: "#", width: "30px" },
-    { name: "Bill Account"},
-    { name: "Client", width: "140px"},
-    { name: "Projects"},
+    { name: "#", width: "30px", maxWidth: "50px" },
+    { name: "Bill Account", width: "250px", maxWidth: "300px"},
+    { name: "Client", width: "100px", maxWidth: "150px"},
+    { name: "Projects", width: "100px", maxWidth: "150px"},
+    { name: "Skills", width: "300px", maxWidth: "300px"},
     { name: "Is Charge", width: "70px", padding : "12px 10px", whiteSpace: "nowrap" },
     { name: "Is Expose", width: "70px", padding : "12px 10px", whiteSpace: "nowrap" },
     { name: "Head Count", width: "100px" },
     { name: "Bill Date", width: "100px" },
-    { name: "Linked Resource", width: "280px" },
+    { name: "Linked Resource"},
     { name: "Note" },
   ];
 
@@ -71,6 +75,13 @@ export class BillAccountPlanComponent
 
   editingRows: { [key: number]: { [key: number]: { [key: string]: boolean } } } = {};
   originalContribute: { [key: number]: { [key: number]: { [key: string]: number } } } = {};
+
+  Resource_TabAllResource_ViewUserStarSkill = PERMISSIONS_CONSTANT.Resource_TabAllResource_ViewUserStarSkill;
+  Resource_TabAllResource_UpdateSkill = PERMISSIONS_CONSTANT.Resource_TabAllResource_UpdateSkill;
+
+  private numberSkill: number = 3;
+  private isViewAllUserSkill: { [userId: number] : boolean } = {};
+
 
   constructor(
     injector: Injector,
@@ -355,5 +366,28 @@ export class BillAccountPlanComponent
   cancelUpdate(source: number, resource: any, index: number): void {
     this.editingRows[source] = {};
     resource.contribute = this.originalContribute[source][index]?.contribute;
+  }
+
+  expandCollapseUserSkill(billId: number) {
+    this.isViewAllUserSkill[billId] = !this.isViewAllUserSkill[billId];
+  }
+
+  updateUserSkill(projectUserBill: projectUserBillDto, note: string) {
+    let ref = this.dialog.open(UpdateUserSkillDialogComponent, {
+      width: "700px",
+      data: {
+        userSkills: projectUserBill.userSkills,
+        id: projectUserBill.userId,
+        fullName: projectUserBill.billAccountName,
+        note: note,
+        viewStarSkillUser: this.permission.isGranted(this.Resource_TabAllResource_ViewUserStarSkill),
+      }
+
+    });
+    ref.afterClosed().subscribe(rs => {
+      if (rs) {
+        this.refresh()
+      }
+    })
   }
 }

--- a/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.ts
+++ b/angular/src/app/modules/delivery-management/delivery/available-resource-tab/bill-account-plan/bill-account-plan.component.ts
@@ -15,6 +15,7 @@ import { ProjectUserBillService } from '@app/service/api/project-user-bill.servi
 import { PERMISSIONS_CONSTANT } from '@app/constant/permission.constant';
 import { projectUserBillDto } from '@app/service/model/project.dto';
 import { UpdateUserSkillDialogComponent } from '@app/users/update-user-skill-dialog/update-user-skill-dialog.component';
+import { IBillInfo, IUserInfor } from '@app/service/model/bill-info.interface';
 
 @Component({
   selector: "app-bill-account-plan",
@@ -38,7 +39,7 @@ export class BillAccountPlanComponent
   public totalHeadCount: number=0;
   public projectId;
   public clientId;
-  public billInfoList = [];
+  public billInfoList: IBillInfo[] = [];
   public projectList = [];
   public clientList = [];
   public listAllResource = []
@@ -372,13 +373,13 @@ export class BillAccountPlanComponent
     this.isViewAllUserSkill[billId] = !this.isViewAllUserSkill[billId];
   }
 
-  updateUserSkill(projectUserBill: projectUserBillDto, note: string) {
+  updateUserSkill(userInfo: IUserInfor, note: string) {
     let ref = this.dialog.open(UpdateUserSkillDialogComponent, {
       width: "700px",
       data: {
-        userSkills: projectUserBill.userSkills,
-        id: projectUserBill.userId,
-        fullName: projectUserBill.billAccountName,
+        userSkills: userInfo.userSkills,
+        id: userInfo.userId,
+        fullName: userInfo.fullName,
         note: note,
         viewStarSkillUser: this.permission.isGranted(this.Resource_TabAllResource_ViewUserStarSkill),
       }

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.css
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.css
@@ -96,6 +96,11 @@
     background: none;
     border: none;
 }
+
+.btn-sm:hover {
+    background: #c3c3c3;
+    border-radius: 5px;
+}
 @media screen and (max-width: 600px) {
     .invoice-setting, .bill-account {
         height: 100% !important;

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.css
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.css
@@ -97,7 +97,7 @@
     border: none;
 }
 
-.btn-sm:hover {
+.btn-hover:hover {
     background: #c3c3c3;
     border-radius: 5px;
 }

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
@@ -519,12 +519,20 @@
                                         </mat-form-field>
                                     </div>
                                 </td>
-                                <td class="text-center">
+                                <td class="text-center" style="position: relative;">
                                     <span class="text-center">
-                                        <mat-checkbox [disabled]="!bill.createMode" [(ngModel)]="bill.isExpose">
+                                        <mat-checkbox [disabled]="!permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Edit)"
+                                            [(ngModel)]="bill.isExpose">
                                         </mat-checkbox>
                                     </span>
-                                     
+                                    <div *ngIf="bill.isExpose != bill.initialIsExpose && !bill.createMode">
+                                        <button class="btn btn-success" (click)="onConfirmUpdateIsExpose(bill)">
+                                            <i class="fa fa-check" aria-hidden="true"></i>
+                                        </button>
+                                        <button class="btn btn-danger" (click)="onCancelUpdateIsExpose(bill)">
+                                            <i class="fa fa-times" aria-hidden="true"></i>
+                                        </button>
+                                    </div>
                                 </td>
                                 <!-- <td class="text-center">
                                         <span class="text-center" *ngIf="!bill.createMode">{{bill.endTime

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
@@ -545,22 +545,56 @@
                                             [(ngModel)]="bill.isActive">
                                         </mat-checkbox>
                                     </td> -->
-                                <td style="min-width: 200px; position: relative;"
-                                    (click)="bill.userSkills.length > numberSkill ? expandUserSkill(bill.id) : null">
+                                <td style="min-width: 250px; width: max-content; max-width: 350px; position: relative;">
                                     <div *ngFor="let skill of (isViewAllUserSkill[bill.id] ? bill.userSkills : bill.userSkills.slice(0, numberSkill))" style="width: 90%;">
-                                        <span>- {{skill.skillName}}</span>
+                                        <span>
+                                            - {{skill.skillName}}
+                                            <strong *ngIf="skill.skillRank && permission.isGranted(Resource_TabAllResource_ViewUserStarSkill)">
+                                                - {{skill.skillRank}}
+                                                <i class="fa fa-star"
+                                                    [ngStyle]="{
+                                                        color: skill.skillRank === 5 ? 'crimson' :
+                                                            skill.skillRank === 4 ? 'orange' :
+                                                            skill.skillRank === 3 ? 'yellow' :
+                                                            skill.skillRank === 1 || skill.skillRank === 2 ? 'grey' : 'inherit'
+                                                    }"
+                                                    style="font-size: 13px;">
+                                                </i>
+                                            </strong>
+                                        </span>
                                         <ng-container *ngIf="!isViewAllUserSkill[bill.id] && bill.userSkills.length > numberSkill && skill === (bill.userSkills.slice(0, numberSkill)[numberSkill - 1])">
-                                            <i class="fas fa-ellipsis-h pl-3"></i>
+                                            <button class="btn btn-sm"
+                                                (click)="expandCollapseUserSkill(bill.id);">
+                                                <i class="fas fa-ellipsis-h"></i>
+                                            </button>
                                         </ng-container>
                                         <ng-container *ngIf="isViewAllUserSkill[bill.id] && skill === (bill.userSkills[bill.userSkills.length - 1])">
-                                            <i class="fas fa-chevron-up pl-3"></i>
+                                            <button class="btn btn-sm"
+                                                (click)="expandCollapseUserSkill(bill.id);">
+                                                <i class="fas fa-chevron-up"></i>
+                                            </button>
                                         </ng-container>
                                     </div>
-                                    <button class="btn btn-sm" style="position: absolute; top: 0; right: 0;">
+                                    <div *ngIf="bill.skillNote">
+                                        <pre class="mb-0 p-0 max-line-content-2"
+                                             PrjResizeContent
+                                             [collapseLine]="2"
+                                             style="
+                                               white-space: pre-line;
+                                               font-family: sans-serif;
+                                               align-self: flex-start;
+                                               line-height: initial;
+                                             ">
+                                                <strong>Note: </strong> {{bill.skillNote}}
+                                          </pre>
+                                    </div>
+                                    <button class="btn btn-sm" style="position: absolute; top: 0; right: 0;"
+                                        *ngIf="permission.isGranted(Resource_TabAllResource_UpdateSkill)"
+                                        (click)="updateUserSkill(bill, bill.skillNote)">
                                         <i class="fas fa-edit"></i>
                                     </button>
                                 </td>
-                                    <td style="white-space: break-spaces;">
+                                <td style="white-space: break-spaces;">
                                     <div class="d-flex align-items-center" style="width: 100%;">
                                             <p style="flex: 1; min-width: 200px; max-width: 100%;"
                                             class="mb-0 p-0 ml-2 ">{{ bill.note }}</p>

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
@@ -242,6 +242,7 @@
                                     
                                     <i  class="fas fa-sort"></i>
                                 </th>
+                                <th class="align">Skills</th>
                                 <th class="align">Note</th>
                                 <th class="align">Action</th>
                             </tr>
@@ -544,7 +545,22 @@
                                             [(ngModel)]="bill.isActive">
                                         </mat-checkbox>
                                     </td> -->
-                                <td style="white-space: break-spaces;">
+                                <td style="min-width: 200px; position: relative;"
+                                    (click)="bill.userSkills.length > numberSkill ? expandUserSkill(bill.id) : null">
+                                    <div *ngFor="let skill of (isViewAllUserSkill[bill.id] ? bill.userSkills : bill.userSkills.slice(0, numberSkill))" style="width: 90%;">
+                                        <span>- {{skill.skillName}}</span>
+                                        <ng-container *ngIf="!isViewAllUserSkill[bill.id] && bill.userSkills.length > numberSkill && skill === (bill.userSkills.slice(0, numberSkill)[numberSkill - 1])">
+                                            <i class="fas fa-ellipsis-h pl-3"></i>
+                                        </ng-container>
+                                        <ng-container *ngIf="isViewAllUserSkill[bill.id] && skill === (bill.userSkills[bill.userSkills.length - 1])">
+                                            <i class="fas fa-chevron-up pl-3"></i>
+                                        </ng-container>
+                                    </div>
+                                    <button class="btn btn-sm" style="position: absolute; top: 0; right: 0;">
+                                        <i class="fas fa-edit"></i>
+                                    </button>
+                                </td>
+                                    <td style="white-space: break-spaces;">
                                     <div class="d-flex align-items-center" style="width: 100%;">
                                             <p style="flex: 1; min-width: 200px; max-width: 100%;"
                                             class="mb-0 p-0 ml-2 ">{{ bill.note }}</p>

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
@@ -87,14 +87,14 @@
                     <div class="header-bill-account">
                         <h4 class="d-inline label-bill-account" style="margin-top: 5px;">Bill accounts ({{ filteredUserBillList.length }}):</h4>
                         <button name="btn-createUserBill" *ngIf="!userBillProcess && permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Create)"
-                            [hidden]="isShowUserBill" style="border: none; height: fit-content;"
+                            [hidden]="isShowUserBill || !showSearchAndFilter" style="border: none; height: fit-content;"
                             class="btn bg-blue ml-2 btn-s mb-2 add-bill-mobile" (click)="addUserBill(); userBillCurrentPage=1; $event.stopPropagation()">
                             <i class="fa fa-plus m-0"></i>
                         </button>
                     </div>
                     <div class="d-flex flex-wrap justify-content-start align-items-center list-filter" style="flex-grow: 1;">
                         <button name="btn-createUserBill" *ngIf="!userBillProcess && permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Create)"
-                            [hidden]="isShowUserBill" style="border: none; height: fit-content;"
+                            [hidden]="isShowUserBill || !showSearchAndFilter" style="border: none; height: fit-content;"
                         class="btn bg-blue ml-2 btn-s mb-2 add-bill-desktop" (click)="addUserBill(); userBillCurrentPage=1; $event.stopPropagation()">
                             <i class="fa fa-plus m-0"></i>
                         </button>
@@ -332,18 +332,18 @@
 
                                     </div>
                                 </td>
-                                <td style="width: 400px;">
+                                <td style="max-width: 400px;">
                                     <div class="text-right" *ngIf="!bill.createLinkResourceMode">
-                                        <button *ngIf="permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount)"
-                                           (click)="addLinkResource(bill)"
-                                           class="btn bg-blue btn-sm"
+                                        <button class="btn bg-blue btn-sm"
+                                            (click)="addLinkResource(bill)"
+                                            [disabled]="bill.createMode || userBillProcess || !permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount)"
                                             style="cursor: pointer; font-size: 10px;">
                                             <i class="fa fa-plus fa-s m-0"></i>
                                         </button>
                                     </div>
-                                    <div *ngIf="bill.createLinkResourceMode" style="width: 400px;" class="row d-flex">
+                                    <div *ngIf="bill.createLinkResourceMode" style="max-width: 400px;" class="row d-flex">
                                         <div class="col-10 mb-2 px-0">
-                                            <mat-form-field appearance="outline" class="col-8">
+                                            <mat-form-field appearance="outline" class="col-9">
                                                 <mat-select panelClass="custom-panel-class" (closed)="focusOut()"
                                                     [(ngModel)]="selectedResource"
                                                     name="userBill"
@@ -367,10 +367,11 @@
                                             </mat-form-field>
                                             <input                
                                                 type="number"
-                                                class="col-4"
+                                                class="col-3"
                                                 placeholder="% contribute"
                                                 min="0"
                                                 max="100"
+                                                matTooltip="% contribute"
                                                 [(ngModel)]="bill.contribute"
                                             />   
                                             <mat-error class="mt-1" *ngIf="userBill.hasError('required') && userBill.touched" style="font-size: 13px;">
@@ -389,10 +390,10 @@
                                                 (click)="cancelLinkResource(bill)"></i>
                                         </div>
                                     </div>
-                                    <div class="d-flex row" style="width: 400px;">
+                                    <div class="d-flex row" style="max-width: 400px;">  
                                         <div class="d-flex col-12 px-0" style="flex-direction: column;">
                                             <div *ngFor="let resource of bill.linkedResources; let i = index" class="mb-2 d-flex px-0">
-                                                <div class="col-8 d-flex px-0">
+                                                <div class="px-0" style="width: 280px;">
                                                     <app-user-info [isSmallerDiv]="true"
                                                         [userData]="resource"
                                                         [isWeeklyReport]="false"
@@ -400,11 +401,12 @@
                                                         >
                                                      </app-user-info>
                                                 </div>
-                                                <div class="col-4 d-flex px-0">
-                                                    <div class="col-6 align-items-end d-flex" [ngClass]="{'col-12': editingRows[bill.id] && editingRows[bill.id][i]?.contribute}">
+                                                <div class="d-flex px-0" style="max-width: 110px;">
+                                                    <div class="align-items-end d-flex mr-1" [ngClass]="{'col-12': editingRows[bill.id] && editingRows[bill.id][i]?.contribute}">
                                                         <span *ngIf="!editingRows[bill.id] || !editingRows[bill.id][i]?.contribute"  
                                                             class="badge text-white" 
                                                             [style.backgroundColor]="Utils.getColorContribute(resource.contribute)"
+                                                            style="width: 40px;"
                                                             matTooltip="Contribute account">
                                                             {{resource.contribute + '%'}}
                                                         </span>
@@ -423,15 +425,17 @@
                                                             appFocus
                                                         />      
                                                     </div>
-                                                    <div class="col-6 align-items-end d-flex">
+                                                    <div class="align-items-end d-flex">
                                                         <button *ngIf="!editingRows[bill.id] || !editingRows[bill.id][i]?.contribute"
                                                             (click)="edit(bill.id, i, 'contribute', resource.contribute)"
-                                                            class="col-6 button-action">
+                                                            [disabled]="bill.createMode || userBillProcess"
+                                                            class="col-6 button-action d-flex justify-content-end">
                                                             <i class="fa fa-pencil-alt"></i>
                                                         </button>
                                                         <button *ngIf="!editingRows[bill.id] || !editingRows[bill.id][i]?.contribute" 
                                                             (click)="removeLinkResource(resource.id, bill.id)"
-                                                            class="col-6 button-action">
+                                                            [disabled]="bill.createMode || userBillProcess"
+                                                            class="col-6 button-action d-flex justify-content-end">
                                                             <i class="fa fa-times"></i>  
                                                         </button>
                                                     </div>
@@ -519,17 +523,19 @@
                                         </mat-form-field>
                                     </div>
                                 </td>
-                                <td class="text-center" style="position: relative;">
+                                <td class="text-center" style="min-width: 100px;">
                                     <span class="text-center">
-                                        <mat-checkbox [disabled]="!permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Edit)"
-                                            [(ngModel)]="bill.isExpose">
+                                        <mat-checkbox  [disabled]="!permission.isGranted(Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Edit) || (userBillProcess && !bill.createMode && bill.isExpose === bill.initialIsExpose)"
+                                            [(ngModel)]="bill.isExpose"
+                                            (change)="!bill.createMode ? onUpdateIsExpose(bill) : null">
                                         </mat-checkbox>
                                     </span>
-                                    <div *ngIf="bill.isExpose != bill.initialIsExpose && !bill.createMode">
-                                        <button class="btn btn-success" (click)="onConfirmUpdateIsExpose(bill)">
+                                    <div *ngIf="bill.isExpose != bill.initialIsExpose && !bill.createMode"
+                                        class="d-flex justify-content-center">
+                                        <button class="text-success btn btn-sm btn-hover" (click)="onConfirmUpdateIsExpose(bill)">
                                             <i class="fa fa-check" aria-hidden="true"></i>
                                         </button>
-                                        <button class="btn btn-danger" (click)="onCancelUpdateIsExpose(bill)">
+                                        <button class="text-danger btn btn-sm btn-hover" (click)="onCancelUpdateIsExpose(bill)">
                                             <i class="fa fa-times" aria-hidden="true"></i>
                                         </button>
                                     </div>
@@ -554,59 +560,66 @@
                                         </mat-checkbox>
                                     </td> -->
                                 <td style="min-width: 250px; width: max-content; max-width: 350px; position: relative;">
-                                    <div *ngFor="let skill of (isViewAllUserSkill[bill.id] ? bill.userSkills : bill.userSkills.slice(0, numberSkill))" style="width: 90%;">
-                                        <span>
-                                            - {{skill.skillName}}
-                                            <strong *ngIf="skill.skillRank && permission.isGranted(Resource_TabAllResource_ViewUserStarSkill)">
-                                                - {{skill.skillRank}}
-                                                <i class="fa fa-star"
-                                                    [ngStyle]="{
-                                                        color: skill.skillRank === 5 ? 'crimson' :
-                                                            skill.skillRank === 4 ? 'orange' :
-                                                            skill.skillRank === 3 ? 'yellow' :
-                                                            skill.skillRank === 1 || skill.skillRank === 2 ? 'grey' : 'inherit'
-                                                    }"
-                                                    style="font-size: 13px;">
-                                                </i>
-                                            </strong>
-                                        </span>
-                                        <ng-container *ngIf="!isViewAllUserSkill[bill.id] && bill.userSkills.length > numberSkill && skill === (bill.userSkills.slice(0, numberSkill)[numberSkill - 1])">
-                                            <button class="btn btn-sm"
-                                                (click)="expandCollapseUserSkill(bill.id);">
-                                                <i class="fas fa-ellipsis-h"></i>
-                                            </button>
-                                        </ng-container>
-                                        <ng-container *ngIf="isViewAllUserSkill[bill.id] && skill === (bill.userSkills[bill.userSkills.length - 1])">
-                                            <button class="btn btn-sm"
-                                                (click)="expandCollapseUserSkill(bill.id);">
-                                                <i class="fas fa-chevron-up"></i>
-                                            </button>
-                                        </ng-container>
+                                    <div *ngIf="bill.userSkills">
+                                        <div *ngFor="let skill of (isViewAllUserSkill[bill.id] ? bill.userSkills : bill.userSkills.slice(0, numberSkill))" style="width: 90%;">
+                                            <span>
+                                                - {{skill.skillName}}
+                                                <strong *ngIf="skill.skillRank && permission.isGranted(Resource_TabAllResource_ViewUserStarSkill)">
+                                                    - {{skill.skillRank}}
+                                                    <i class="fa fa-star"
+                                                        [ngStyle]="{
+                                                            color: skill.skillRank === 5 ? 'crimson' :
+                                                                skill.skillRank === 4 ? 'orange' :
+                                                                skill.skillRank === 3 ? 'yellow' :
+                                                                skill.skillRank === 1 || skill.skillRank === 2 ? 'grey' : 'inherit'
+                                                        }"
+                                                        style="font-size: 13px;">
+                                                    </i>
+                                                </strong>
+                                            </span>
+                                            <ng-container *ngIf="!isViewAllUserSkill[bill.id] && bill.userSkills.length > numberSkill && skill === (bill.userSkills.slice(0, numberSkill)[numberSkill - 1])">
+                                                <button class="btn btn-sm btn-hover"
+                                                    (click)="expandCollapseUserSkill(bill.id);">
+                                                    <i class="fas fa-ellipsis-h"></i>
+                                                </button>
+                                            </ng-container>
+                                            <ng-container *ngIf="isViewAllUserSkill[bill.id] && skill === (bill.userSkills[bill.userSkills.length - 1])">
+                                                <button class="btn btn-sm btn-hover"
+                                                    (click)="expandCollapseUserSkill(bill.id);">
+                                                    <i class="fas fa-chevron-up"></i>
+                                                </button>
+                                            </ng-container>
+                                        </div>
+                                        <div *ngIf="bill.skillNote">
+                                            <pre class="mb-0 p-0 max-line-content-2"
+                                                 PrjResizeContent
+                                                 [collapseLine]="2"
+                                                 style="
+                                                   white-space: pre-line;
+                                                   font-family: sans-serif;
+                                                   align-self: flex-start;
+                                                   line-height: initial;
+                                                 ">
+                                                    <strong>Note: </strong> {{bill.skillNote}}
+                                              </pre>
+                                        </div>
+                                        <button class="btn btn-sm" style="position: absolute; top: 0; right: 0;"
+                                            [disabled]="!permission.isGranted(Resource_TabAllResource_UpdateSkill) || userBillProcess"
+                                            (click)="updateUserSkill(bill, bill.skillNote)">
+                                            <i class="fas fa-edit"></i>
+                                        </button>
                                     </div>
-                                    <div *ngIf="bill.skillNote">
-                                        <pre class="mb-0 p-0 max-line-content-2"
-                                             PrjResizeContent
-                                             [collapseLine]="2"
-                                             style="
-                                               white-space: pre-line;
-                                               font-family: sans-serif;
-                                               align-self: flex-start;
-                                               line-height: initial;
-                                             ">
-                                                <strong>Note: </strong> {{bill.skillNote}}
-                                          </pre>
-                                    </div>
-                                    <button class="btn btn-sm" style="position: absolute; top: 0; right: 0;"
-                                        *ngIf="permission.isGranted(Resource_TabAllResource_UpdateSkill)"
-                                        (click)="updateUserSkill(bill, bill.skillNote)">
-                                        <i class="fas fa-edit"></i>
-                                    </button>
                                 </td>
                                 <td style="white-space: break-spaces;">
                                     <div class="d-flex align-items-center" style="width: 100%;">
                                             <p style="flex: 1; min-width: 200px; max-width: 100%;"
                                             class="mb-0 p-0 ml-2 ">{{ bill.note }}</p>
-                                            <i style="color: #585858;" class="fas fa-ellipsis-v ml-1" [matMenuTriggerFor]="menu3"></i>
+                                            <button *ngIf="!bill.createMode"
+                                                class="btn btn-sm"
+                                                [disabled]="userBillProcess"
+                                                [matMenuTriggerFor]="menu3">
+                                                <i class="fas fa-ellipsis-v ml-1"></i>
+                                            </button>
                                         <mat-menu #menu3="matMenu">
                                             <button class="mat-menu-item" (click)="editBillNote(bill)">
                                                 <i class="fas fa-edit mr-2 fa-lg"></i>
@@ -621,7 +634,7 @@
                                               [disabled]="userBillProcess" mat-button [matMenuTriggerFor]="actionMenu"><i class="fas fa-bars fa-lg"></i></button>
                                         <!-- Define the mat-menu and its content -->
                                         <mat-menu #actionMenu="matMenu">
-                                              <button mat-menu-item (click)="editUserBill(bill)" [hidden]="!showSearchAndFilter">
+                                              <button mat-menu-item (click)="editUserBill(bill)">
                                                 <i class="fas fa-pencil-alt"></i> Edit
                                             </button>
                                             <button mat-menu-item (click)="removeUserBill(bill)">
@@ -630,17 +643,21 @@
                                         </mat-menu>
                                     </div>
 
-                                    <div *ngIf="bill.createMode" class="pt-1 d-flex" style="flex-direction: column;">
-                                        <button
-                                            [disabled]="!bill?.userId || !bill?.billRole || !bill?.startTime  || bill?.billRate<0 || !bill?.billRate || !bill?.headCount || bill?.headCount<0 || bill?.headCount>1  "
-                                            class="mb-3 submit-btn" style="background: none; border: none;"
-                                                [hidden]="showSearchAndFilter"
-                                                (click)="saveUserBill(bill)">
-                                            <i style="color: green; font-size: 30px;" class="fas fa-check fa-2x "></i>
+                                    <div *ngIf="bill.createMode"
+                                        class="pt-1 d-flex"
+                                        style="flex-direction: column;">
+                                        <button class="mb-3 submit-btn"
+                                            [disabled]="!bill?.userId || !bill?.billRole || !bill?.startTime || bill?.billRate<0 || !bill?.billRate || !bill?.headCount || bill?.headCount<0 || bill?.headCount>1"
+                                            style="background: none; border: none;"
+                                            (click)="saveUserBill(bill)">
+                                            <i style="color: green; font-size: 30px;"
+                                                class="fas fa-check fa-2x">
+                                            </i>
                                         </button>
-                                        <i style="color: red; font-size: 30px;" class="fas fa-undo fa-2x"
-                                                [hidden]="showSearchAndFilter"
-                                                (click)="cancelUserBill(bill)"></i>
+                                        <i style="color: red; font-size: 30px;"
+                                            class="fas fa-undo fa-2x"
+                                            (click)="cancelUserBill(bill)">
+                                        </i>
                                     </div>
                                 </td>
                             </tr>

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
@@ -284,6 +284,7 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
               this.userBillProcess = true;
               this.showSearchAndFilter = false;
               this.isAddingOrEditingUserBill = true;
+              userBill.initialIsExpose = userBill.isExpose;
             }
           }
         );
@@ -321,7 +322,7 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
       },
         () => {
           userBill.createMode = true;
-          this.isLoading = false
+          this.isLoading = false;
         }
         )
       }
@@ -452,8 +453,13 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
     this.projectUserBillService.GetProjectUserBillById(id).pipe(
       catchError(this.projectUserBillService.handleError)
     ).subscribe(data => {
-        let updated = data.result;
-        this.filteredUserBillList = this.filteredUserBillList.map(item => (item.userId === updated.userId ? updated : item));
+        let updated = data.result as projectUserBillDto;
+        this.filteredUserBillList = this.filteredUserBillList.map(item => {
+          if (item.id === id) {
+            return { ...updated, initialIsExpose: updated.isExpose };
+          }
+          return {...item, initialIsExpose: item.isExpose};
+        });
         this.isLoading = false;
     }, () => { this.isLoading = false; });
   }
@@ -869,6 +875,14 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
 
   onCancelUpdateIsExpose(userBill: projectUserBillDto) {
     userBill.isExpose = userBill.initialIsExpose;
+    this.userBillProcess = false;
+    this.showSearchAndFilter = true;
+  }
+
+  onUpdateIsExpose(userBill: projectUserBillDto) {
+    const hasChanged = userBill.isExpose !== userBill.initialIsExpose;
+    this.userBillProcess = hasChanged;
+    this.showSearchAndFilter = !hasChanged;
   }
 }
 

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
@@ -410,6 +410,7 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
     this.searchUserBill = "";
     this.showSearchAndFilter = true;
     this.isAddingOrEditingUserBill = false;
+    userBill.isExpose = userBill.initialIsExpose;
   }
   public editUserBill(userBill: projectUserBillDto): void {
     this.userIdOld = userBill.userId
@@ -418,6 +419,7 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
     this.isEditUserBill = true;
     this.showSearchAndFilter = false;
     this.isAddingOrEditingUserBill = true;
+    userBill.isExpose = userBill.initialIsExpose;
   }
   private getUserBill(id?: number, status?: boolean, userIdNew?: number): void {
     this.isLoading = true;
@@ -435,9 +437,9 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
       this.totalHeadCount = data.result.reduce((sum, item) => sum + item.headCount, 0);
         this.userBillList = data.result.map(item => {
             if (item.id === id && userIdNew) {
-                return { ...item, createMode: status, userId: userIdNew };
+                return { ...item, createMode: status, userId: userIdNew, initialIsExpose: item.isExpose };
             }
-            return { ...item, createMode: false, contribute: 0 };
+            return { ...item, createMode: false, contribute: 0, initialIsExpose: item.isExpose };
         });
 
         this.filteredUserBillList = _.cloneDeep(this.userBillList);
@@ -858,6 +860,15 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
         this.refresh()
       }
     })
+  }
+
+  onConfirmUpdateIsExpose(userBill: projectUserBillDto) {
+    this.updateUserBill(userBill);
+    userBill.initialIsExpose = userBill.isExpose;
+  }
+
+  onCancelUpdateIsExpose(userBill: projectUserBillDto) {
+    userBill.isExpose = userBill.initialIsExpose;
   }
 }
 

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
@@ -30,6 +30,7 @@ import { optionDto } from '@shared/components/multiple-select/multiple-select.co
 import * as _ from 'lodash';
 import { ResourceManagerService } from '@app/service/api/resource-manager.service';
 import * as FileSaver from 'file-saver';
+import { UpdateUserSkillDialogComponent } from '@app/users/update-user-skill-dialog/update-user-skill-dialog.component';
 
 
 @Component({
@@ -104,8 +105,8 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
   editingRows: { [key: number]: { [key: number]: { [key: string]: boolean } } } = {};
   originalContribute: { [key: number]: { [key: number]: { [key: string]: number } } } = {};
 
-  private numberSkill: number = 4;
-  private isViewAllUserSkill: { [userId: number] : boolean } = {}; 
+  private numberSkill: number = 3;
+  private isViewAllUserSkill: { [userId: number] : boolean } = {};
 
   Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_View = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_View;
   Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Create = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Create;
@@ -115,8 +116,10 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
   Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Note_Edit = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Note_Edit;
   Projects_OutsourcingProjects_ProjectDetail_TabWeeklyReport = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabWeeklyReport;
   Projects_OutsourcingProjects_ProjectDetail_TabWeeklyReport_View = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabWeeklyReport_View;
-  Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount
-
+  Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount;
+  Resource_TabAllResource_ViewUserStarSkill = PERMISSIONS_CONSTANT.Resource_TabAllResource_ViewUserStarSkill;
+  Resource_TabAllResource_UpdateSkill = PERMISSIONS_CONSTANT.Resource_TabAllResource_UpdateSkill;
+  
   constructor(private router: Router,
     private projectUserBillService: ProjectUserBillService,
     private route: ActivatedRoute,
@@ -834,8 +837,27 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
     }, () => { this.isLoading = false; });
   }
 
-  expandUserSkill(billId: number) {
+  expandCollapseUserSkill(billId: number) {
     this.isViewAllUserSkill[billId] = !this.isViewAllUserSkill[billId];
+  }
+
+  updateUserSkill(projectUserBill: projectUserBillDto, note: string) {
+    let ref = this.dialog.open(UpdateUserSkillDialogComponent, {
+      width: "700px",
+      data: {
+        userSkills: projectUserBill.userSkills,
+        id: projectUserBill.userId,
+        fullName: projectUserBill.billAccountName,
+        note: note,
+        viewStarSkillUser: this.permission.isGranted(this.Resource_TabAllResource_ViewUserStarSkill),
+      }
+
+    });
+    ref.afterClosed().subscribe(rs => {
+      if (rs) {
+        this.refresh()
+      }
+    })
   }
 }
 

--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.ts
@@ -104,6 +104,9 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
   editingRows: { [key: number]: { [key: number]: { [key: string]: boolean } } } = {};
   originalContribute: { [key: number]: { [key: number]: { [key: string]: number } } } = {};
 
+  private numberSkill: number = 4;
+  private isViewAllUserSkill: { [userId: number] : boolean } = {}; 
+
   Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_View = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_View;
   Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Create = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Create;
   Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Edit = PERMISSIONS_CONSTANT.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_Edit;
@@ -829,6 +832,10 @@ export class ProjectBillComponent extends AppComponentBase implements OnInit {
       this.isLoading = false;
       this.editingRows[projectUserBillId] = {};
     }, () => { this.isLoading = false; });
+  }
+
+  expandUserSkill(billId: number) {
+    this.isViewAllUserSkill[billId] = !this.isViewAllUserSkill[billId];
   }
 }
 

--- a/angular/src/app/service/model/bill-info.interface.ts
+++ b/angular/src/app/service/model/bill-info.interface.ts
@@ -1,0 +1,72 @@
+export interface IBillInfo {
+    userInfor: IUserInfor;
+    projects: IProject[];
+    totalHeadCount: number;
+}
+
+export interface IUserInfor {
+    userId: number;
+    avatarPath: string | null;
+    fullName: string;
+    branch: number;
+    branchColor: string;
+    branchDisplayName: string;
+    positionId: number;
+    positionName: string;
+    positionColor: string;
+    emailAddress: string;
+    simplizeEmailAddress: string;
+    userType: number;
+    userLevel: number;
+    userSkills: IUserSkill[];
+    skillNote: string;
+}
+
+export interface IUserSkill {
+    userId: number;
+    skillId: number;
+    skillName: string;
+    skillRank: number;
+    skillNote: string;
+}
+
+export interface IProject {
+    billId: number;
+    projectId: number;
+    projectName: string;
+    projectStatus: number;
+    accountName: string;
+    billRate: number;
+    headCount: number;
+    startTime: string; // ISO 8601 format
+    endTime: string | null;
+    note: string | null;
+    isActive: boolean;
+    isExpose: boolean;
+    chargeType: string | null;
+    currencyCode: string;
+    projectCode: string | null;
+    clientId: number;
+    clientCode: string;
+    clientName: string;
+    rateDisplay: string;
+    linkedResources: ILinkedResource[];
+}
+
+export interface ILinkedResource {
+    emailAddress: string;
+    avatarPath: string;
+    avatarFullPath: string;
+    userType: number;
+    userLevel: number;
+    isActive: boolean;
+    fullName: string;
+    userName: string;
+    branchColor: string;
+    branchDisplayName: string;
+    positionId: number;
+    positionColor: string;
+    positionName: string;
+    contribute: number;
+    id: number;
+}

--- a/angular/src/app/service/model/project.dto.ts
+++ b/angular/src/app/service/model/project.dto.ts
@@ -115,6 +115,15 @@ export class projectUserBillDto {
   linkCV: string;
   totalHeadCount:number;
   contribute: number;
+  userSkills: ProjectUserSkillDto[];
+}
+
+export class ProjectUserSkillDto{
+  userId: number;
+  skillId: number;
+  skillName: string;
+  skillRank: number;
+  skillNote: string;
 }
 
 export class ProjectRateDto {

--- a/angular/src/app/service/model/project.dto.ts
+++ b/angular/src/app/service/model/project.dto.ts
@@ -116,7 +116,8 @@ export class projectUserBillDto {
   totalHeadCount:number;
   contribute: number;
   userSkills: ProjectUserSkillDto[];
-  skillNote: string; 
+  skillNote: string;
+  initialIsExpose: boolean;
 }
 
 export class ProjectUserSkillDto{

--- a/angular/src/app/service/model/project.dto.ts
+++ b/angular/src/app/service/model/project.dto.ts
@@ -116,6 +116,7 @@ export class projectUserBillDto {
   totalHeadCount:number;
   contribute: number;
   userSkills: ProjectUserSkillDto[];
+  skillNote: string; 
 }
 
 export class ProjectUserSkillDto{

--- a/aspnet-core/src/ProjectManagement.Application/APIs/ProjectUserBills/Dto/BillInfoDto.cs
+++ b/aspnet-core/src/ProjectManagement.Application/APIs/ProjectUserBills/Dto/BillInfoDto.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Text;
+using ProjectManagement.Services.ResourceService.Dto;
 using static ProjectManagement.Constants.Enum.ClientEnum;
 using static ProjectManagement.Constants.Enum.ProjectEnum;
 
@@ -39,6 +40,8 @@ namespace ProjectManagement.APIs.ProjectUserBills.Dto
         public string SimplizeEmailAddress => this.EmailAddress.Split('@')[0];
         public UserType UserType { get; set; }
         public UserLevel UserLevel { get; set; }
+        public List<UserSkillDto> UserSkills { get; set; }
+        public string SkillNote { get; set; }
 
         public bool Equals(GetUserBillDto other)
         {

--- a/aspnet-core/src/ProjectManagement.Application/APIs/ProjectUserBills/ProjectUserBillAppService.cs
+++ b/aspnet-core/src/ProjectManagement.Application/APIs/ProjectUserBills/ProjectUserBillAppService.cs
@@ -251,6 +251,15 @@ namespace ProjectManagement.APIs.ProjectUserBills
                 EmailAddress = x.User.EmailAddress,
                 UserType = x.User.UserType,
                 UserLevel = x.User.UserLevel,
+                UserSkills = x.User.UserSkills.Select(s => new UserSkillDto()
+                {
+                    UserId = s.UserId,
+                    SkillId = s.SkillId,
+                    SkillName = s.Skill.Name,
+                    SkillRank = s.SkillRank,
+                    SkillNote = s.Note
+                }).ToList(),
+                SkillNote = x.User.UserSkills.Select(s => s.Note).FirstOrDefault() ?? ""
             },
             Project = new GetProjectBillDto
             {

--- a/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/Dto/GetProjectUserBillDto.cs
+++ b/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/Dto/GetProjectUserBillDto.cs
@@ -53,5 +53,6 @@ namespace ProjectManagement.Services.ProjectUserBill.Dto
         public GridParam GridParam { get; set; }
         public string LinkCV { get; set; }
         public List<UserSkillDto> UserSkills { get; set; }
+        public string SkillNote { get; set; }
     }
 }

--- a/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/Dto/GetProjectUserBillDto.cs
+++ b/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/Dto/GetProjectUserBillDto.cs
@@ -5,6 +5,7 @@ using ProjectManagement.Utils;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using ProjectManagement.Services.ResourceService.Dto;
 using static ProjectManagement.Constants.Enum.ProjectEnum;
 
 namespace ProjectManagement.Services.ProjectUserBill.Dto
@@ -51,5 +52,6 @@ namespace ProjectManagement.Services.ProjectUserBill.Dto
         public float totalHeadCount { get; set; }
         public GridParam GridParam { get; set; }
         public string LinkCV { get; set; }
+        public List<UserSkillDto> UserSkills { get; set; }
     }
 }

--- a/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/ProjectUserBillManager.cs
+++ b/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/ProjectUserBillManager.cs
@@ -206,7 +206,8 @@ namespace ProjectManagement.Services.ProjectUserBills
                             IsActive = lr.User.IsActive,
                             FullName = lr.User.FullName,
                             Contribute = lr.Contribute
-                        }).ToList()
+                        }).ToList(),
+                    SkillNote = x.User.UserSkills.Select(s => s.Note).FirstOrDefault() ?? ""
                 });
 
 

--- a/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/ProjectUserBillManager.cs
+++ b/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/ProjectUserBillManager.cs
@@ -281,7 +281,16 @@ namespace ProjectManagement.Services.ProjectUserBills
                             IsActive = lr.User.IsActive,
                             FullName = lr.User.FullName,
                             Contribute = lr.Contribute
-                        }).ToList()
+                        }).ToList(),
+                    UserSkills = x.User.UserSkills.Select(us => new UserSkillDto
+                    {
+                        UserId = us.UserId,
+                        SkillId = us.SkillId,
+                        SkillName = us.Skill.Name,
+                        SkillRank = us.SkillRank,
+                        SkillNote = us.Note
+                    }).ToList(),
+                    SkillNote = x.User.UserSkills.Select(s => s.Note).FirstOrDefault() ?? ""
                 }).FirstOrDefault();
         }
          

--- a/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/ProjectUserBillManager.cs
+++ b/aspnet-core/src/ProjectManagement.Core/Services/ProjectUserBill/ProjectUserBillManager.cs
@@ -181,7 +181,14 @@ namespace ProjectManagement.Services.ProjectUserBills
                     ChargeType = x.ChargeType ?? x.Project.ChargeType,
                     CreationTime = x.CreationTime,
                     LinkCV = x.LinkCV,
-
+                    UserSkills = x.User.UserSkills.Select(us => new UserSkillDto
+                    {
+                        UserId = us.UserId,
+                        SkillId = us.SkillId,
+                        SkillName = us.Skill.Name,
+                        SkillRank = us.SkillRank,
+                        SkillNote = us.Note
+                    }).ToList(),
                     LinkedResources = x.LinkedResources
                         .Select(lr => new GetUserInfo
                         {


### PR DESCRIPTION
```
V. Thêm cột skill cho Bill acc ở:
	- project detail> bill accounts
	- Resource > Bill account: cột skills  ở sau cột projects
	-> có thể thêm và xóa skill của bill acc ở 2 màn trên
	- chú ý: nếu nhiều skill quá -> chỉ hiển thị 3 hay 4 skill thôi, click vào thì mới hiển thị hết
	- phải update db
	- Update 'Note' trong Resource -> Bill Acc (responsive theo nội dung để khỏi scroll)
	
+ update UX để có thể edit cột Is Expose mà ko phải edit cả row: Bill Info
```