### PR TITLE
feat: hide employee column in timesheet modal, rename charge name col…

### DIFF
--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/project-bill/project-bill.component.html
@@ -195,7 +195,7 @@
                                 </th> 
                                 <th class="align " (click)="sortData('billAccountName')" style="cursor: pointer;">
                                     <div class="col-bill-account">
-                                        {{ "Charge Name" | localize }}
+                                        {{ "Charge Name + CV" | localize }}
                                         <i class="icon" [ngClass]="iconSort" *ngIf="sortColumn === 'billAccountName'"></i>
                                         <i *ngIf="sortColumn !== 'billAccountName'" class="fas fa-sort"></i>
                                     </div>

--- a/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.html
+++ b/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.html
@@ -75,7 +75,7 @@
           <thead class="bg-light">
             <tr>
               <th class="stt">#</th>
-              <th style="width: 350px;">Employee</th>
+              <!-- <th style="width: 350px;">Employee</th> -->
               <th style="width: 200px;">Charge Name</th>
               <th style="width: 150px;">Charge Role</th>
               <th style="width: 100px;" *ngIf="isShowRate()">Rate<br>({{getCurrencyName()}})</th>
@@ -94,8 +94,8 @@
               <td>
                 <span>{{ i + 1 }}</span>
               </td>
-              <td class="text-left" style="min-width: 200px">
-                  <!-- <app-user-info
+              <!-- <td class="text-left" style="min-width: 200px">
+                  <app-user-info
                     [userData]="{
                       fullName: bill.fullName,
                       branch: bill.branch,
@@ -107,12 +107,12 @@
                       userLevel: bill.userLevel
                     }"
                   >
-                  </app-user-info> -->
+                  </app-user-info>
                   <app-user-info
                     [userData]="bill"
                   >
                   </app-user-info>
-              </td>
+              </td> -->
 
               <!-- Charge Name -->
               <td class="text-center">


### PR DESCRIPTION
…umn in Bill accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the column header text in the user bill accounts table to display "Charge Name + CV" instead of "Charge Name".
  * Commented out the "Employee" column and its content in the bill details view, removing it from display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->