### PR TITLE
fix: preserve edited fields when changing status of weekly report (2)

### DIFF
--- a/angular/src/app/modules/pm-management/list-project/list-project-detail/weekly-report/weekly-report.component.ts
+++ b/angular/src/app/modules/pm-management/list-project/list-project-detail/weekly-report/weekly-report.component.ts
@@ -385,16 +385,16 @@ export class WeeklyReportComponent extends PagedListingComponentBase<WeeklyRepor
             })
     }
 
-onChangeStatusProject() {
+    onChangeStatusProject() {
         this.pjCriteriaResultService.updateStatus(this.statusProject, this.selectedReport.reportId, this.projectId).subscribe(data => {
             abp.notify.success("Update status project successful");
-            // this.getAllCriteria();
-            this.listCriteriaResult = this.listCriteriaResult.map(item => {
-                return { ...item, status: this.statusProject }
-            })
-            this.listPreEditCriteriaResult = this.listPreEditCriteriaResult.map(item => {
-                return { ...item, status: this.statusProject, editMode: item.editMode ?? false }
-            });
+            this.getAllCriteria();
+            // this.listCriteriaResult = this.listCriteriaResult.map(item => {
+            //     return { ...item, status: this.statusProject }
+            // })
+            // this.listPreEditCriteriaResult = this.listPreEditCriteriaResult.map(item => {
+            //     return { ...item, status: this.statusProject, editMode: item.editMode ?? false }
+            // });
             // this.listPreEditCriteriaResult.forEach(s => s.editMode = false);
         }, () => { this.statusProject = this.statusProjectHistory }
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of status updates in the weekly report by ensuring criteria results are refreshed after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->