### PR TITLE
Fix: allow expand note content in TS

### DIFF
--- a/angular/src/app/modules/timesheet/timesheet-detail/timesheet-detail.component.html
+++ b/angular/src/app/modules/timesheet/timesheet-detail/timesheet-detail.component.html
@@ -303,9 +303,9 @@
                       <div class="col-2" *ngIf="isGranted(Timesheets_TimesheetDetail_ViewBillRate)"><label
                           class="ml-1">{{bill.roundAmount | number: "1.0":"en-US" }} {{item.currency}}</label></div>
 
-                      <div class="text-right note" [ngClass]="isGranted(Timesheets_TimesheetDetail_ViewBillRate)?'col-2 ml-4':'col-5'"
-                        style="word-break: break-all; white-space: pre-line;">
-                        <div title="{{bill.description?bill.description:''}}" class="no-expand-text">
+                      <div class="text-left note" [ngClass]="isGranted(Timesheets_TimesheetDetail_ViewBillRate)?'col-2 ml-4':'col-5'"
+                        style=" white-space: pre-line;">
+                        <div title="{{bill.description?bill.description:''}}" PrjResizeContent [collapseLine]="1">
                           {{bill.description?bill.description:''}}
                         </div>
                       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timesheet Detail: Bill description is now collapsible (shows a single-line preview with expand/collapse), making long notes easier to scan.

* **Style**
  * Timesheet Detail: Note/Bill info is left-aligned for improved readability.
  * Text handling refined: preserves line breaks without breaking words mid-word, resulting in a cleaner, more legible layout, especially on narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->