### PR TITLE
63099 - Update: hide Update User To Bill Account button withou permission

### DIFF
--- a/angular/src/app/modules/pm-management/product-projects/product-project-detail/product-account-info/product-account-info.component.html
+++ b/angular/src/app/modules/pm-management/product-projects/product-project-detail/product-account-info/product-account-info.component.html
@@ -259,8 +259,9 @@
                                 <td style="max-width: 400px;">
                                     <div class="text-right" *ngIf="!bill.createLinkResourceMode">
                                         <button class="btn bg-blue btn-sm"
+                                            *ngIf="permission.isGranted(Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount)"
                                             (click)="addLinkResource(bill)"
-                                            [disabled]="bill.createMode || userBillProcess || !permission.isGranted(Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount)"
+                                            [disabled]="bill.createMode || userBillProcess "
                                             style="cursor: pointer; font-size: 10px;">
                                             <i class="fa fa-plus fa-s m-0"></i>
                                         </button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Add Link Resource” button in Product Account Info now respects user permissions: it’s only shown to authorized users instead of appearing disabled for others.
  * Disabled state is simplified to reflect only creation or in-progress states, reducing confusion and preventing unintended interactions.
  * Improves clarity and aligns the interface with expected access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->