### PR TITLE
Fix: hidding linked resources column

### DIFF
--- a/angular/src/app/constant/permission.constant.ts
+++ b/angular/src/app/constant/permission.constant.ts
@@ -318,7 +318,7 @@ export const PERMISSIONS_CONSTANT = {
        Projects_ProductProjects_ProjectDetail_TabBillInfo_Edit: "Projects.ProductProjects.ProjectDetail.TabBillInfo.Edit",
        Projects_ProductProjects_ProjectDetail_TabBillInfo_Delete: "Projects.ProductProjects.ProjectDetail.TabBillInfo.Delete",
        Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit: "Projects.ProductProjects.ProjectDetail.TabBillInfo.Note_Edit",
-       Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount: "Projects.ProductProjects.ProjectDetail.TabBillInfo.UpdateUserToBillAccount",
+       // Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount: "Projects.ProductProjects.ProjectDetail.TabBillInfo.UpdateUserToBillAccount",
        Projects_ProductProjects_ProjectDetail_TabTimesheet: "Projects.ProductProjects.ProjectDetail.TabTimesheet",
 
        Projects_ProductProjects_ProjectDetail_TabProjectDescription: "Projects.ProductProjects.ProjectDetail.TabProjectDescription",

--- a/angular/src/app/modules/pm-management/product-projects/product-project-detail/product-account-info/product-account-info.component.html
+++ b/angular/src/app/modules/pm-management/product-projects/product-project-detail/product-account-info/product-account-info.component.html
@@ -45,7 +45,7 @@
                             </div>
                         </div> -->
 
-                        <div class="col-lg-4 mb-2 filter-link-resource" (click)="$event.stopPropagation()" [hidden]="!showSearchAndFilter">
+                        <!-- <div class="col-lg-4 mb-2 filter-link-resource" (click)="$event.stopPropagation()" [hidden]="!showSearchAndFilter">
                             <app-multiple-select
                             [hidden]="isShowUserBill"
                             #linkedResources
@@ -62,7 +62,7 @@
                                 *ngIf="selectedLinkedResources.length > 0"
                             (click)="onCancelFilterLinkedResources()"
                             ></i>
-                        </div>
+                        </div> -->
 
                         <!-- <div class="mb-2 change-role" (click)="$event.stopPropagation()" [hidden]="!showSearchAndFilter">
                             <app-multiple-select-string-value
@@ -127,13 +127,13 @@
                                         <i *ngIf="sortColumn !== 'billRole'" class="fas fa-sort"></i>
                                     </div>
                                 </th> -->
-                                    <th class="align" (click)="orderLinkedResourcesOnTop('linkedResources')" style="cursor: pointer;">
+                                    <!-- <th class="align" (click)="orderLinkedResourcesOnTop('linkedResources')" style="cursor: pointer;">
                                         <div class="col-bill-account">
                                             {{ "Linked Resources" | localize }}
                                             <i class="icon" [ngClass]="iconSort" *ngIf="sortColumn === 'linkedResources'"></i>
                                             <i *ngIf="sortColumn !== 'linkedResources'" class="fas fa-sort"></i>
                                         </div>
-                                </th>
+                                </th> -->
                                 <th class="align" (click)="sortData('headCount')" style="cursor: pointer; min-width: 100px;">
                                 {{ "Head Count" | localize }}
                                 <br>({{totalHeadCount | number: '1.2-2'}})
@@ -256,7 +256,7 @@
 
                                     </div>
                                 </td> -->
-                                <td style="max-width: 400px;">
+                                <!-- <td style="max-width: 400px;">
                                     <div class="text-right" *ngIf="!bill.createLinkResourceMode">
                                         <button class="btn bg-blue btn-sm"
                                             *ngIf="permission.isGranted(Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount)"
@@ -369,7 +369,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                </td>
+                                </td> -->
                                 <td class="text-center">
                                     <span class="text-center" *ngIf="!bill.createMode">{{ bill.headCount |
                                         number: '1.2-2':'en-US' }}</span>

--- a/angular/src/app/modules/pm-management/product-projects/product-project-detail/product-account-info/product-account-info.component.ts
+++ b/angular/src/app/modules/pm-management/product-projects/product-project-detail/product-account-info/product-account-info.component.ts
@@ -78,7 +78,7 @@ export class ProductAccountInfoComponent extends AppComponentBase implements OnI
   public listSelectChargeRole: string[] = [];
 
   public selectedLinkedResources: number[] = [];
-  public listSelectLinkedResources: optionDto[] = [];
+  // public listSelectLinkedResources: optionDto[] = [];
   // public isHideRates:boolean = false;
 
   public listAllResource: UserDto[] = [];
@@ -97,7 +97,7 @@ export class ProductAccountInfoComponent extends AppComponentBase implements OnI
   Projects_ProductProjects_ProjectDetail_TabBillInfo_Edit = PERMISSIONS_CONSTANT.Projects_ProductProjects_ProjectDetail_TabBillInfo_Edit;
   Projects_ProductProjects_ProjectDetail_TabBillInfo_Delete = PERMISSIONS_CONSTANT.Projects_ProductProjects_ProjectDetail_TabBillInfo_Delete;
   Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit = PERMISSIONS_CONSTANT.Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit;
-  Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount = PERMISSIONS_CONSTANT.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount;
+  // Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount = PERMISSIONS_CONSTANT.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount;
   Resource_TabAllResource_ViewUserStarSkill = PERMISSIONS_CONSTANT.Resource_TabAllResource_ViewUserStarSkill;
   Resource_TabAllResource_UpdateSkill = PERMISSIONS_CONSTANT.Resource_TabAllResource_UpdateSkill;
 
@@ -118,7 +118,7 @@ export class ProductAccountInfoComponent extends AppComponentBase implements OnI
   ngOnInit(): void {
     this.getUserBill();
     this.GetChargeRoleData();
-    this.GetLinkedResourcesData();
+    // this.GetLinkedResourcesData();
     this.getCurrentProjectInfo();
     this.getListUserAndResources();
   }
@@ -380,16 +380,16 @@ export class ProductAccountInfoComponent extends AppComponentBase implements OnI
     })
   }
 
-  GetLinkedResourcesData(){
-    this.projectUserBillService.GetAllLinkedResourcesByProject(this.projectId).subscribe(data => {
-      this.listSelectLinkedResources = data.result.map(item => {
-        return {
-          id: item.id,
-          name: `${item.fullName} (${item.emailAddress})`
-        };
-      });
-    })
-  }
+  // GetLinkedResourcesData(){
+  //   this.projectUserBillService.GetAllLinkedResourcesByProject(this.projectId).subscribe(data => {
+  //     this.listSelectLinkedResources = data.result.map(item => {
+  //       return {
+  //         id: item.id,
+  //         name: `${item.fullName} (${item.emailAddress})`
+  //       };
+  //     });
+  //   })
+  // }
 
   filterByIsCharge() {
     this.getUserBill()

--- a/aspnet-core/src/ProjectManagement.Application/APIs/ProjectUserBills/ProjectUserBillAppService.cs
+++ b/aspnet-core/src/ProjectManagement.Application/APIs/ProjectUserBills/ProjectUserBillAppService.cs
@@ -85,7 +85,7 @@ namespace ProjectManagement.APIs.ProjectUserBills
         [HttpPost]
         [AbpAuthorize(
             PermissionNames.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,
-            PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,
+ /*           PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,*/
             PermissionNames.Projects_TrainingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount
         )]
         public async Task<bool> LinkUserToBillAccount(LinkedResourcesDto input)
@@ -97,7 +97,7 @@ namespace ProjectManagement.APIs.ProjectUserBills
         [HttpPost]
         [AbpAuthorize(
             PermissionNames.Projects_OutsourcingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,
-            PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,
+/*            PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,*/
             PermissionNames.Projects_TrainingProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount
         )]
         public async Task<bool> RemoveLinkedResource(LinkedResourcesDto input)

--- a/aspnet-core/src/ProjectManagement.Core/Authorization/PermissionNames.cs
+++ b/aspnet-core/src/ProjectManagement.Core/Authorization/PermissionNames.cs
@@ -346,7 +346,7 @@ namespace ProjectManagement.Authorization
         public const string Projects_ProductProjects_ProjectDetail_TabBillInfo_Edit = "Projects.ProductProjects.ProjectDetail.TabBillInfo.Edit";
         public const string Projects_ProductProjects_ProjectDetail_TabBillInfo_Delete = "Projects.ProductProjects.ProjectDetail.TabBillInfo.Delete";
         public const string Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit = "Projects.ProductProjects.ProjectDetail.TabBillInfo.Note_Edit";
-        public const string Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount = "Projects.ProductProjects.ProjectDetail.TabBillInfo.UpdateUserToBillAccount";
+/*        public const string Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount = "Projects.ProductProjects.ProjectDetail.TabBillInfo.UpdateUserToBillAccount";*/
 
         public const string Projects_ProductProjects_ProjectDetail_TabTimesheet = "Projects.ProductProjects.ProjectDetail.TabTimesheet";
 
@@ -1074,7 +1074,7 @@ namespace ProjectManagement.Authorization
                     PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Edit ,
                     PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Delete ,
                     PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit ,
-                    PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,
+/*                    PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount,*/
 
                     PermissionNames.Projects_ProductProjects_ProjectDetail_TabTimesheet ,
 
@@ -1809,7 +1809,7 @@ namespace ProjectManagement.Authorization
                  new SystemPermission{ Name =  PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Edit, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Edit" },
                  new SystemPermission{ Name =  PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Delete, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Delete" },
                  new SystemPermission{ Name =  PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Edit Note" },
-                 new SystemPermission{ Name =  PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Update User To BillAccount" },
+                 /*new SystemPermission{ Name =  PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Update User To BillAccount" },*/
 
                  new SystemPermission{ Name =  PermissionNames.Projects_ProductProjects_ProjectDetail_TabTimesheet, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Tab Timesheet" },
 
@@ -3054,9 +3054,9 @@ namespace ProjectManagement.Authorization
                                                      new SystemPermission {
                                                         Name = PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_Note_Edit, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Edit Note"
                                                     },
-                                                    new SystemPermission {
+                                                    /*new SystemPermission {
                                                         Name = PermissionNames.Projects_ProductProjects_ProjectDetail_TabBillInfo_UpdateUserToBillAccount, MultiTenancySides = MultiTenancySides.Host | MultiTenancySides.Tenant, DisplayName = "Update User To Bill Account"
-                                                    }
+                                                    }*/
                                                 }
                                         },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- UI Changes
  - Removed the Linked Resources column, filters, and add/edit controls from Product Project Account Info.

- Permissions
  - Retired the “update user to bill account” permission for Product Projects.
  - Adjusted access rules for linking/removing users to bill accounts to align with remaining project types.

- Chores
  - Cleaned up unused permissions and related UI/logic to reflect the updated access model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->