### PR TITLE
Fix OT type add/update to refresh list without reloading project bill

### DIFF
--- a/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.ts
+++ b/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.ts
@@ -73,51 +73,59 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
     this.otTypeProcess = false;
   }
 
-  public saveTimesheetBillOt(billDetail: TimesheetProjectBill): void {
-    const ot = this.otTypeOptions.find(ot => ot.otTypeName === billDetail.otType);
-    if (!ot) {
-      abp.notify.error("Invalid OT type");
-      return;
-    }
+private findOtTypeByName(otTypeName: string) {
+  return this.otTypeOptions.find(ot => ot.otTypeName === otTypeName);
+}
 
-    const existed = billDetail.otTypes?.some(x => x.projectOtTypeId === ot.id);
-    if (existed) {
-      abp.notify.error("This OT type already exists for this bill");
-      return;
-    }
-    const newTimesheetBillOt = {
-      timesheetProjectBillId: billDetail.id,
-      projectOtTypeId: ot.id,
-      hours: billDetail.otHours,
-      mode: 0
-    };
+private isOtTypeExisted(billDetail: TimesheetProjectBill, projectOtTypeId: any): boolean {
+  return billDetail.otTypes?.some(x => x.projectOtTypeId === projectOtTypeId) || false;
+}
 
-    this.timesheetProjectBillService.createOrUpdateTimesheetBillOt(newTimesheetBillOt)
+private buildTimesheetBillOtPayload(billDetail: TimesheetProjectBill, projectOtTypeId: any) {
+  return {
+    timesheetProjectBillId: billDetail.id,
+    projectOtTypeId: projectOtTypeId,
+    hours: billDetail.otHours,
+    mode: 0
+  };
+}
+
+private resetBillDetailOtForm(billDetail: TimesheetProjectBill): void {
+  billDetail.createTimesheetBillOtMode = false;
+  billDetail.otType = null;
+  billDetail.otHours = null;
+  this.otTypeProcess = false;
+}
+
+private createTimesheetBillOt(payload: any, billDetail: TimesheetProjectBill): void {
+  this.timesheetProjectBillService.createOrUpdateTimesheetBillOt(payload)
     .pipe(catchError(this.timesheetProjectBillService.handleError))
     .subscribe({
-      next: (res: any) => {
+      next: () => {
         abp.notify.success("OT user added successfully");
-        const newOt = {
-          id: res.result ,
-          projectOtTypeId: ot.id,
-          otType: ot.otTypeName,
-          otHours: billDetail.otHours,
-          isEditing: false
-        };
-
-        billDetail.otTypes = billDetail.otTypes || [];
-        billDetail.otTypes.push(newOt);
-        billDetail.createTimesheetBillOtMode = false;
-        billDetail.otType = null;
-        billDetail.otHours = null;
-        this.otTypeProcess = false;
+        this.resetBillDetailOtForm(billDetail);
+        this.getProjectBill();
       },
       error: () => {
         billDetail.createTimesheetBillOtMode = true;
-        this.otTypeProcess = false;
       }
     });
+}
+ 
+public saveTimesheetBillOt(billDetail: TimesheetProjectBill): void {
+  const ot = this.findOtTypeByName(billDetail.otType);
+  if (!ot) {
+    abp.notify.error("Invalid OT type");
+    return;
   }
+
+  if (this.isOtTypeExisted(billDetail, ot.id)) {
+    abp.notify.error("This OT type already exists for this bill");
+    return;
+  }
+  const newTimesheetBillOt = this.buildTimesheetBillOtPayload(billDetail, ot.id);
+  this.createTimesheetBillOt(newTimesheetBillOt, billDetail);
+}
 
   public editTimesheetBillOt(ot: any): void {
     ot.isEditing = true;
@@ -149,22 +157,18 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
 
     this.otTypeProcess = true;
     this.timesheetProjectBillService.createOrUpdateTimesheetBillOt(updatePayload)
-    .subscribe({
-      next: (res: any) => {
-        abp.notify.success("OT user updated successfully");
-
-        ot.id = res.result;
-        ot.projectOtTypeId = otType.id;
-        ot.otType = otType.otTypeName;
-        ot.otHours = updatePayload.hours;
-        ot.isEditing = false;
-        this.otTypeProcess = false;
-      },
-      error: (err) => {
-        console.error(err);
-        this.otTypeProcess = false;
-      }
-    });
+      .subscribe({
+        next: (res: any) => {
+          abp.notify.success("OT user updated successfully");
+          ot.isEditing = false;
+          this.otTypeProcess = false;
+          this.getProjectBill();
+        },
+        error: (err) => {
+          console.error(err);
+          this.otTypeProcess = false;
+        }
+      });
   }
 
   getProjectOtTypesById(projectId: any) {
@@ -204,7 +208,7 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
           this.isLoading = true;
           this.timesheetProjectBillService.removeTimesheetBillOt(req).pipe(catchError(this.timesheetProjectBillService.handleError)).subscribe(data => {
             abp.notify.success(`OT user Removed Successfully!`)
-            billDetail.otTypes = billDetail.otTypes?.filter(x => x.id !== ot.id);
+            this.getProjectBill();
           }, () => {
             this.isLoading = false
           })
@@ -425,7 +429,6 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
         abp.notify.success(response.result)
         this.setViewAllRow();
         this.getProjectBill();
-        this.otTypeProcess = false;
       }
       else{
         abp.notify.error(response.message)

--- a/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.ts
+++ b/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.ts
@@ -93,17 +93,30 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
     };
 
     this.timesheetProjectBillService.createOrUpdateTimesheetBillOt(newTimesheetBillOt)
-      .pipe(catchError(this.timesheetProjectBillService.handleError))
-      .subscribe(() => {
+    .pipe(catchError(this.timesheetProjectBillService.handleError))
+    .subscribe({
+      next: (res: any) => {
         abp.notify.success("OT user added successfully");
+        const newOt = {
+          id: res.result ,
+          projectOtTypeId: ot.id,
+          otType: ot.otTypeName,
+          otHours: billDetail.otHours,
+          isEditing: false
+        };
+
+        billDetail.otTypes = billDetail.otTypes || [];
+        billDetail.otTypes.push(newOt);
         billDetail.createTimesheetBillOtMode = false;
         billDetail.otType = null;
         billDetail.otHours = null;
         this.otTypeProcess = false;
-        this.getProjectBill();
-      }, () => {
+      },
+      error: () => {
         billDetail.createTimesheetBillOtMode = true;
-      });
+        this.otTypeProcess = false;
+      }
+    });
   }
 
   public editTimesheetBillOt(ot: any): void {
@@ -136,18 +149,22 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
 
     this.otTypeProcess = true;
     this.timesheetProjectBillService.createOrUpdateTimesheetBillOt(updatePayload)
-      .subscribe({
-        next: (res: any) => {
-          abp.notify.success("OT user updated successfully");
-          ot.isEditing = false;
-          this.otTypeProcess = false;
-          this.getProjectBill();
-        },
-        error: (err) => {
-          console.error(err);
-          this.otTypeProcess = false;
-        }
-      });
+    .subscribe({
+      next: (res: any) => {
+        abp.notify.success("OT user updated successfully");
+
+        ot.id = res.result;
+        ot.projectOtTypeId = otType.id;
+        ot.otType = otType.otTypeName;
+        ot.otHours = updatePayload.hours;
+        ot.isEditing = false;
+        this.otTypeProcess = false;
+      },
+      error: (err) => {
+        console.error(err);
+        this.otTypeProcess = false;
+      }
+    });
   }
 
   getProjectOtTypesById(projectId: any) {
@@ -187,7 +204,7 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
           this.isLoading = true;
           this.timesheetProjectBillService.removeTimesheetBillOt(req).pipe(catchError(this.timesheetProjectBillService.handleError)).subscribe(data => {
             abp.notify.success(`OT user Removed Successfully!`)
-            this.getProjectBill();
+            billDetail.otTypes = billDetail.otTypes?.filter(x => x.id !== ot.id);
           }, () => {
             this.isLoading = false
           })
@@ -408,6 +425,7 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
         abp.notify.success(response.result)
         this.setViewAllRow();
         this.getProjectBill();
+        this.otTypeProcess = false;
       }
       else{
         abp.notify.error(response.message)

--- a/aspnet-core/src/ProjectManagement.Application/APIs/TimeSheetProjectBills/TimeSheetProjectBillAppService.cs
+++ b/aspnet-core/src/ProjectManagement.Application/APIs/TimeSheetProjectBills/TimeSheetProjectBillAppService.cs
@@ -210,7 +210,7 @@ namespace ProjectManagement.APIs.TimeSheetProjectBills
         }
 
         [HttpPost]
-        public async Task CreateOrUpdateTimesheetBillOt(CreateOrUpdateTimesheetBillOtDto input)
+        public async Task<long> CreateOrUpdateTimesheetBillOt(CreateOrUpdateTimesheetBillOtDto input)
         {
             var timesheetProjectBill = await WorkScope.GetAll<TimesheetProjectBill>()
                 .FirstOrDefaultAsync(x => x.Id == input.TimesheetProjectBillId)
@@ -224,8 +224,9 @@ namespace ProjectManagement.APIs.TimeSheetProjectBills
 
                 entity.ProjectOtTypeId = input.ProjectOtTypeId;
                 entity.Hours = input.Hours;
-
+            
                 await WorkScope.UpdateAsync(entity);
+                return entity.Id;
             }
             else
             {
@@ -236,7 +237,7 @@ namespace ProjectManagement.APIs.TimeSheetProjectBills
                     Hours = input.Hours
                 };
 
-                await WorkScope.InsertAsync(entity);
+                return await WorkScope.InsertAndGetIdAsync(entity);
             }
 
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents duplicate OT types when adding OT; shows validation and preserves edit mode on error to allow retry.
  - OT add/save now resets OT form and updates bill data instantly without full reload; UI processing indicators and states remain consistent.

- Refactor
  - Consolidated OT save flow with centralized validation, payload handling, and unified success/error handling for more reliable feedback.
  - Backend now returns created/updated OT identifiers, enabling smoother in-app updates and fewer refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->