### PR TITLE
fixed display workingday

### DIFF
--- a/angular/src/app/modules/timesheet/timesheet-detail/timesheet-detail.component.ts
+++ b/angular/src/app/modules/timesheet/timesheet-detail/timesheet-detail.component.ts
@@ -211,7 +211,7 @@ export class TimesheetDetailComponent extends PagedListingComponentBase<Timeshee
   }
 
   getOtDays(hours: number): number {
-    return parseFloat((hours / 8).toFixed(2));
+    return parseFloat((hours / 8).toFixed(3));
   }
   
   getTotalWorkingTime(item: any): number {
@@ -226,7 +226,7 @@ export class TimesheetDetailComponent extends PagedListingComponentBase<Timeshee
       const otHours = hours * multiplier;
       return total + this.getOtDays(otHours);
     }, 0) || 0;
-    return parseFloat((normalWorkingTime + totalOtTime).toFixed(2));  }
+    return parseFloat((normalWorkingTime + totalOtTime).toFixed(3));  }
 
   isShowBtnExportTsDetail() {
     return this.isGranted(this.Timesheets_TimesheetDetail_ExportTSdetail)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved precision of overtime calculations: OT day fractions now display with three decimal places (was two).
  - Total overtime time and overall working time now use three-decimal rounding, reducing rounding discrepancies in timesheet details.
  - Ensures more accurate and consistent figures across entries and summaries, enhancing clarity for reviews and approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->