### PR TITLE
#OT type

### DIFF
--- a/angular/src/app/modules/timesheet/timesheet-detail/timesheet-detail.component.ts
+++ b/angular/src/app/modules/timesheet/timesheet-detail/timesheet-detail.component.ts
@@ -217,16 +217,16 @@ export class TimesheetDetailComponent extends PagedListingComponentBase<Timeshee
   getTotalWorkingTime(item: any): number {
     const normalWorkingTime = item.workingTime || 0;
 
-      if (!item.timesheetProjectBillOtTypes?.length) {
+    if (!item.timesheetProjectBillOtTypes?.length) {
       return normalWorkingTime;
     }
-    const totalOtTime = item?.timesheetProjectBillOtTypes?.reduce((total: number, otType: any) => {
+    const totalOtTime = item.timesheetProjectBillOtTypes.reduce((total: number, otType: any) => {
       const hours = otType?.hours ?? 0;
-      const multiplier = otType?.multiplier ?? 1;
-      const otHours = hours * multiplier;
-      return total + this.getOtDays(otHours);
+      return total + this.getOtDays(hours);
     }, 0) || 0;
-    return parseFloat((normalWorkingTime + totalOtTime).toFixed(3));  }
+
+    return parseFloat((normalWorkingTime + totalOtTime).toFixed(3));  
+  }
 
   isShowBtnExportTsDetail() {
     return this.isGranted(this.Timesheets_TimesheetDetail_ExportTSdetail)

--- a/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.html
+++ b/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.html
@@ -42,7 +42,7 @@
         </div>
 
         <!-- OT Unit Dropdown -->
-        <div class="ml-2" *ngIf="!isEditingAllRow()">
+        <div class="ml-2" *ngIf="!isEditingAllRow() && hasOTTypes">
           <mat-form-field appearance="outline" style="width: 150px">
             <mat-label>OT Unit</mat-label>
             <mat-select [(ngModel)]="otUnit" name="otUnit">
@@ -128,7 +128,7 @@
               <th
                 style="width: 300px; white-space: break-spaces"
                 *ngIf="
-                  data.action === updateAction.UpdateTimesheet && isShowOTType()
+                  data.action === updateAction.UpdateTimesheet && isShowOTType() && hasOTTypes
                 "
               >
                 OT Time
@@ -274,12 +274,11 @@
               </td>
 
               <!-- OT Time -->
-              <!-- OT Time -->
               <td
                 class="text-center"
                 style="width: 300px"
                 *ngIf="
-                  data.action === updateAction.UpdateTimesheet && isShowOTType()
+                  data.action === updateAction.UpdateTimesheet && isShowOTType() && hasOTTypes
                 "
               >
                 <!-- Add button - CHỈ HIỆN KHI ĐANG EDIT -->

--- a/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.ts
+++ b/angular/src/app/modules/timesheet/timesheet-detail/view-bill/view-bill.component.ts
@@ -36,6 +36,7 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
   public isCreate: boolean = false;
   public isEdit: boolean = false;
   public isEdittingRows: boolean = false;
+  public hasOTTypes: boolean  = false;
   tempUserList = []
   public chargeTypeList = [{name:'Daily', value: 0}, {name:'Monthly', value: 1}, {name:'Hourly', value: 2}];
   public updateAction = UpdateAction
@@ -270,6 +271,9 @@ export class ViewBillComponent extends AppComponentBase implements OnInit {
       .subscribe((res: any) => {
         if (res.success) {
           this.otTypeOptions = res.result;
+          if(this.otTypeOptions && this.otTypeOptions.length > 0){
+            this.hasOTTypes = true;
+          }
         } else {
           abp.notify.error(res.message || "Failed to fetch OT types");
         }

--- a/aspnet-core/src/ProjectManagement.Application/APIs/TimeSheetProjectBills/TimeSheetProjectBillAppService.cs
+++ b/aspnet-core/src/ProjectManagement.Application/APIs/TimeSheetProjectBills/TimeSheetProjectBillAppService.cs
@@ -1,20 +1,16 @@
 ﻿using Abp.Authorization;
-using Abp.Runtime.Session;
 using Abp.UI;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NccCore.Extension;
-using NccCore.Paging;
 using ProjectManagement.APIs.ProjectUserBills.Dto;
 using ProjectManagement.APIs.TimeSheetProjectBills.Dto;
 using ProjectManagement.Authorization;
-using ProjectManagement.Authorization.Roles;
 using ProjectManagement.Authorization.Users;
 using ProjectManagement.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using static ProjectManagement.Constants.Enum.ProjectEnum;
 
@@ -224,7 +220,7 @@ namespace ProjectManagement.APIs.TimeSheetProjectBills
 
                 entity.ProjectOtTypeId = input.ProjectOtTypeId;
                 entity.Hours = input.Hours;
-            
+
                 await WorkScope.UpdateAsync(entity);
                 return entity.Id;
             }
@@ -243,7 +239,7 @@ namespace ProjectManagement.APIs.TimeSheetProjectBills
         }
 
         [HttpGet]
-        public async Task<List<OtTypeDto>> GetProjectOtTypesById (int projectId)
+        public async Task<List<OtTypeDto>> GetProjectOtTypesById(int projectId)
         {
             var listProjectOtTypes = await WorkScope.GetAll<ProjectOtType>()
                 .Where(x => x.ProjectId == projectId)


### PR DESCRIPTION
- If the project does not have any OT Types setup, the Update TS modal will not need to show the OT Time column and OT dropdown.
- On the table [Timesheets]  where the total number of days is displayed, edit it to show the total number without multiplying the coefficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated overtime calculation logic to improve accuracy of total working time.

* **New Features**
  * Added conditional visibility for overtime-related UI elements; fields now display only when overtime types are available.

* **Chores**
  * Removed unused dependencies and improved code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->