### PR TITLE
Fix OT Multiplier

### DIFF
--- a/aspnet-core/src/ProjectManagement.Application/APIs/TimesheetProjects/TimesheetProjectAppService.cs
+++ b/aspnet-core/src/ProjectManagement.Application/APIs/TimesheetProjects/TimesheetProjectAppService.cs
@@ -900,10 +900,13 @@ namespace ProjectManagement.APIs.TimesheetProjects
                         rowRange.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
                         rowRange.Style.Fill.BackgroundColor.SetColor(rowIndex % 2 == 0 ? white : ivory);
 
+                        // Calculate total OT (in days or hours) based on OT type and user settings
                         var workingDayOt = ExtensionMethod.GetWorkingDayOT(ot, tsUser);
-                        var otBillRate = tsUser.BillRateDisplay * ot.Multiplier;
+                        var otMultiplier = Math.Round((double)ot.Multiplier, 3);
+                        var otBillRate = tsUser.BillRateDisplay * otMultiplier;
                         var lineTotalOt = workingDayOt * otBillRate;
 
+                        // Fill OT row
                         invoiceSheet.Cells[rowIndex, 2].Value = $"{tsUser.FullName} ({ot.OtType})";
                         invoiceSheet.Cells[rowIndex, 3].Value = tsUser.ProjectName;
                         invoiceSheet.Cells[rowIndex, 4].Value = otBillRate;

--- a/aspnet-core/src/ProjectManagement.Application/Helper/ExportInvoicePDFHelper.cs
+++ b/aspnet-core/src/ProjectManagement.Application/Helper/ExportInvoicePDFHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using ProjectManagement.Services.Timesheet.Dto;
+using System;
 using System.Globalization;
 using System.Text;
 
@@ -43,9 +44,13 @@ namespace ProjectManagement.Helper
                 {
                     foreach (var ot in tsUser.TimesheetProjectBillOtTypes)
                     {
+                        // Calculate total OT (in days or hours) based on OT type and user settings
                         var workingDayOt = ExtensionMethod.GetWorkingDayOT(ot, tsUser);
-                        var otBillRate = tsUser.BillRateDisplay * ot.Multiplier;
+                        var otMultiplier = Math.Round((double)ot.Multiplier, 3);
+                        var otBillRate = tsUser.BillRateDisplay * otMultiplier;
                         var lineTotalOt = workingDayOt * otBillRate;
+
+                        // Fill OT row
                         evenClass = (rowIndex % 2 == 0) ? "" : "_even";
                         builder.Append($@"
                         <tr class='row14'>


### PR DESCRIPTION
- Fix OT Multiplier round 3 decimal places

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected overtime multiplier rounding precision in invoice calculations. Overtime rates are now rounded to 3 decimal places before calculating line totals, ensuring consistent and accurate overtime amounts across Excel and PDF invoice exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->